### PR TITLE
Add building and container recipes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.10)
+project("SSE Cmake Example")
+
+find_package(Boost REQUIRED COMPONENTS filesystem)
+find_package(yaml-cpp REQUIRED CONFIG)
+
+FIND_PACKAGE(deal.II REQUIRED HINTS ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR})
+DEAL_II_INITIALIZE_CACHED_VARIABLES()
+
+add_executable(main main.cpp fem/fem.cpp flatset/flatset.cpp filesystem/filesystem.cpp yamlParser/yamlParser.cpp)
+DEAL_II_SETUP_TARGET(main)
+
+target_link_libraries(main Boost::filesystem yaml-cpp)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:22.04
+COPY inittimezone /usr/local/bin/inittimezone
+RUN inittimezone
+RUN apt update -y && apt install -y vim git build-essential cmake wget libdeal.ii-dev libboost-all-dev mpich && rm -rf /var/lib/apt/lists/*
+RUN mkdir /project
+WORKDIR /project
+RUN git clone https://github.com/jbeder/yaml-cpp.git
+RUN mkdir -p yaml-cpp/build && cd yaml-cpp/build && cmake .. && make && make install
+COPY . ./
+RUN mkdir build; cd build; cmake ..; make

--- a/main.cpp
+++ b/main.cpp
@@ -1,39 +1,39 @@
-//#include "fem/fem.hpp"
-//#include "flatset/flatset.hpp"
-//#include "filesystem/filesystem.hpp"
-//#include "yamlParser/yamlParser.hpp"
+#include "fem/fem.hpp"
+#include "flatset/flatset.hpp"
+#include "filesystem/filesystem.hpp"
+#include "yamlParser/yamlParser.hpp"
 #include <iostream>
 
 int main(int argc, char *argv[])
 {
   std::cout << "Let's fight with CMake, Docker, and some dependencies!" << std::endl << std::endl;
 
-  //std::cout << "Solve Poisson problem with FEM using deal.II" << std::endl;
-  //Fem fem;
-  //fem.run();
-  //std::cout << std::endl;
+  std::cout << "Solve Poisson problem with FEM using deal.II" << std::endl;
+  Fem fem;
+  fem.run();
+  std::cout << std::endl;
 
-  //std::cout << "Modify a flat set using boost container" << std::endl;
-  //modifyAndPrintSets();
-  //std::cout << std::endl;
+  std::cout << "Modify a flat set using boost container" << std::endl;
+  modifyAndPrintSets();
+  std::cout << std::endl;
 
-  //std::cout << "Inspect the current directory using boost filesystem" << std::endl;
-  //inspectDirectory();
-  //std::cout << std::endl;
+  std::cout << "Inspect the current directory using boost filesystem" << std::endl;
+  inspectDirectory();
+  std::cout << std::endl;
 
   
-  //if ( argc == 2 )
-  //{
-  //  const std::string yamlFile( argv[1] );
-  //  std::cout << "Parse some yaml file with yaml-cpp" << std::endl;
-  //  std::cout << "  " << yamlFile << std::endl;
-  //  parseConfig( yamlFile );
-  //}
-  //else
-  //{
-  //  std::cout << "To parse a yaml file please specify file on command line" << std::endl;
-  //  std::cout << "  ./cpackexample YAMLFILE" << std::endl;
-  //}
+  if ( argc == 2 )
+  {
+    const std::string yamlFile( argv[1] );
+    std::cout << "Parse some yaml file with yaml-cpp" << std::endl;
+    std::cout << "  " << yamlFile << std::endl;
+    parseConfig( yamlFile );
+  }
+  else
+  {
+    std::cout << "To parse a yaml file please specify file on command line" << std::endl;
+    std::cout << "  ./cpackexample YAMLFILE" << std::endl;
+  }
 
   return 0;
 }


### PR DESCRIPTION
The code can simply be executed by building the Dockerfile e.g. with `docker build -t cmake-erwerljs .`.
This installs dependencies, compiles and installs yaml-cpp and then builds the final project.
However the build does not make use of the new version of yaml-cpp because after 3 hours of trying to convince cmake/ld to actually use the new library I decided that there are more important things in life.

This executable can be found in `/project/build/main`